### PR TITLE
Fixing bug where opacity slider doesn't update

### DIFF
--- a/library/src/main/java/com/larswerkman/lobsterpicker/sliders/LobsterOpacitySlider.java
+++ b/library/src/main/java/com/larswerkman/lobsterpicker/sliders/LobsterOpacitySlider.java
@@ -79,9 +79,7 @@ public class LobsterOpacitySlider extends LobsterSlider {
         updateColor();
         chain.setColor(this, chainedColor);
 
-        if(Color.alpha(color) != 0xFF){
-            setOpacity(Color.alpha(color));
-        }
+        setOpacity(Color.alpha(color));
         invalidate();
     }
 


### PR DESCRIPTION
When setting the color on the LobsterPicker with an attached opacity slider
the opacity does not always update correctly. An example use case where it
will not update and it should is:

1) Set the lobster picker to a color with alpha either in code or by using it
   such as: 0xA0FF0000
2) Set the lobster picker to a color with no alpha in code such as: 0xFFFF0000
3) Notice that the alpha slider is still incorectly showing the old alpha value of A0
