### PR TITLE
Compatibility with oder Android versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "24.0.0"
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 7
         targetSdkVersion 24
         versionCode buildTime()
         versionName VERSION_NAME
@@ -22,6 +22,7 @@ def buildTime() {
 
 dependencies {
     compile 'com.android.support:support-annotations:24.0.0'
+    compile 'com.nineoldandroids:library:2.4.0'
     javadocDeps 'com.android.support:support-annotations:24.0.0'
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,12 +3,12 @@ import java.text.SimpleDateFormat
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.0"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode buildTime()
         versionName VERSION_NAME
     }
@@ -21,8 +21,8 @@ def buildTime() {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:23.1.1'
-    javadocDeps 'com.android.support:support-annotations:23.1.1'
+    compile 'com.android.support:support-annotations:24.0.0'
+    javadocDeps 'com.android.support:support-annotations:24.0.0'
 }
 
 apply from: 'gradle-mvn-push.gradle'

--- a/library/src/main/java/com/larswerkman/lobsterpicker/LobsterPicker.java
+++ b/library/src/main/java/com/larswerkman/lobsterpicker/LobsterPicker.java
@@ -15,7 +15,6 @@
  */
 package com.larswerkman.lobsterpicker;
 
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -35,6 +34,7 @@ import android.view.MotionEvent;
 import android.view.View;
 
 import com.larswerkman.lobsterpicker.adapters.BitmapColorAdapter;
+import com.nineoldandroids.animation.ValueAnimator;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/library/src/main/java/com/larswerkman/lobsterpicker/LobsterSlider.java
+++ b/library/src/main/java/com/larswerkman/lobsterpicker/LobsterSlider.java
@@ -15,7 +15,6 @@
  */
 package com.larswerkman.lobsterpicker;
 
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -26,6 +25,8 @@ import android.graphics.PointF;
 import android.support.annotation.ColorInt;
 import android.util.AttributeSet;
 import android.view.View;
+
+import com.nineoldandroids.animation.ValueAnimator;
 
 /**
  * Abstract slider view to set up default size's and paints

--- a/library/src/main/java/com/larswerkman/lobsterpicker/sliders/LobsterOpacitySlider.java
+++ b/library/src/main/java/com/larswerkman/lobsterpicker/sliders/LobsterOpacitySlider.java
@@ -15,7 +15,6 @@
  */
 package com.larswerkman.lobsterpicker.sliders;
 
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -28,6 +27,7 @@ import android.view.MotionEvent;
 
 import com.larswerkman.lobsterpicker.LobsterPicker;
 import com.larswerkman.lobsterpicker.LobsterSlider;
+import com.nineoldandroids.animation.ValueAnimator;
 
 /**
  * Slider that is able to manipulate the Opacity value of a color.

--- a/library/src/main/java/com/larswerkman/lobsterpicker/sliders/LobsterShadeSlider.java
+++ b/library/src/main/java/com/larswerkman/lobsterpicker/sliders/LobsterShadeSlider.java
@@ -15,8 +15,6 @@
  */
 package com.larswerkman.lobsterpicker.sliders;
 
-import android.animation.AnimatorSet;
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -33,6 +31,8 @@ import com.larswerkman.lobsterpicker.LobsterSlider;
 import com.larswerkman.lobsterpicker.OnColorListener;
 import com.larswerkman.lobsterpicker.R;
 import com.larswerkman.lobsterpicker.adapters.BitmapColorAdapter;
+import com.nineoldandroids.animation.AnimatorSet;
+import com.nineoldandroids.animation.ValueAnimator;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Using the [NineOldAndroids](https://github.com/JakeWharton/NineOldAndroids) library, I adjusted Lobsterpicker to work on older Android versions (I set the minSdk to 7, though it might work on even older versions). I tested it on and API 10 (Android 2.3.3) emulator and it seems to work.

Even though I could understand if you declined this PR due to the deprecated state of the NineOldAndroids library or due to the few KB of bloat it adds to the project, I think there are still many apps out there that need to support API 7+ and are thus not able to use your nice color picker in its current state. Supporting API 7+ would put this library on the same level as most of Google's Android Support Libraries.

In the process of integrating NineOldAndroids, I also updated the Android Gradle Plugin, compileSDK, targetSDK and support library versions to their newest versions, respectively.
